### PR TITLE
LIBLIBI-234. Exclude sync from staff-blog image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-# Ignore the database dump
-sync/drupaldb.dump
+.git
 vendor/
+sites/default/files

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,19 +29,16 @@ RUN wget -O drush.phar https://github.com/drush-ops/drush-launcher/releases/down
 # Remove the default drupal codebase
 RUN rm -rf /var/www/html/*
 
-COPY sync /app/sync
-
 COPY docker/vhost.conf /etc/apache2/sites-enabled/000-default.conf
 
 COPY docker/settings.php /app/settings.php
 
-# Copy the staff-blog codebase to /app/web
+# Copy the staff-blog codebase to /app/web/blog
 COPY . /app/web/blog
 
-# Install dependcies, set ownership and delete the sync dir under /app/web
+# Install dependcies, set ownership and delete the sync dir under /app/web/blog
 RUN cd /app/web/blog && \
 	composer install --no-dev && \
-	chown -R www-data:www-data /app/web && \
-	rm -rf /app/web/sync
+	chown -R www-data:www-data /app/web/blog
 
-WORKDIR /app
+WORKDIR /app/web/blog

--- a/docker/DockerReadme.md
+++ b/docker/DockerReadme.md
@@ -1,18 +1,8 @@
 # Building the staff-blog image
 
-## Prerequisites
-
-Clone the staff-blog-configuration to a direcotry named `sync` under the staff-blog repo.
-
-Assuming staff-blog codebase is checked out at `/apps/git/staff-blog`:
-
-    cd /apps/git/staff-blog
-    git clone git@bitbucket.org:umd-lib/staff-blog-configuration.git sync
-
-
 ## Build
 
-From the `/apps/git/staff-blog` directory:
+From the `/apps/git/staff-blog` (or `/apps/git/libi` depending where the code is cloned to) directory:
 
     docker build .
 


### PR DESCRIPTION
- The sync will mounted directly to container from the docker-host server.
- Also, exluded unnecessary directories.

https://issues.umd.edu/browse/LIBLIBI-234